### PR TITLE
🐳

### DIFF
--- a/.registry/Dockerfile
+++ b/.registry/Dockerfile
@@ -29,7 +29,7 @@ ENV OP_ITEM = ""
 # Install playwright
 ##
 RUN apt-get update && \
-  apt-get -y install chromium xvfb && \
+  apt-get -y install chromium-sandbox xvfb && \
   pip install -U pip && \
   pip install playwright && \
   playwright install chromium && playwright install-deps && \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ iamlistening = "5.3.27"
 findmyorder = "2.2.11"
 dxsp = "11.1.4"
 cefi = "5.3.4"
-myllm = "4.13.18"
+myllm = "4.13.19"
 
 [tool.poetry.group.dev.dependencies]
 python-semantic-release = ">=8.0.8"


### PR DESCRIPTION
## Summary by Sourcery

Update Dockerfile to use chromium-sandbox and bump myllm dependency version.

Build:
- Update Dockerfile to install chromium-sandbox instead of chromium.

Chores:
- Bump myllm dependency version from 4.13.18 to 4.13.19 in pyproject.toml.