### PR TITLE
🔊 verifying settings merger

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
   "cefi==7.0.3", # Pinned
   "iamlistening==6.0.3", # Pinned
   "findmyorder==4.0.1", # Pinned
-  "myllm==4.19.8", # Pinned
+  "myllm==4.19.10", # Pinned
 ]
 
 [project.urls]

--- a/tt/config.py
+++ b/tt/config.py
@@ -101,6 +101,7 @@ else:
 
 ROOT = os.path.dirname(__file__)
 
+
 # Get config directory from environment or use a default
 config_dir = os.getenv("TT_CONFIG_DIR", os.path.dirname(ROOT))
 loguru_logger.debug(f"Config directory: {config_dir}")
@@ -135,15 +136,22 @@ for location in settings_locations:
             loguru_logger.debug(f"Found settings file: {potential_path}")
             settings_files.append(potential_path)
 
+# Ensure logging of settings loaded
+loguru_logger.debug(f"Settings files to be loaded: {settings_files}")
+
+# Load the settings using Dynaconf
 settings = Dynaconf(
     envvar_prefix="TT",
     root_path=os.path.dirname(ROOT),
     load_dotenv=True,
     settings_files=settings_files,
     environments=True,
-    merge_enabled=True,
+    merge_enabled=True,  # Ensure merging is enabled
     default_env="default",
 )
+
+# Log the loaded settings for verification
+loguru_logger.debug(f"Loaded settings: {settings.to_dict()}")
 
 
 ########################################


### PR DESCRIPTION
## Summary by Sourcery

Add debug logging around Dynaconf settings loading to verify merge functionality and bump the MyLLM dependency version.

Enhancements:
- Add debug logging of settings files discovered prior to loading.
- Add debug logging of loaded settings state after merging.
- Ensure the merge_enabled flag is explicitly enabled in Dynaconf initialization.

Build:
- Bump myllm dependency from 4.19.8 to 4.19.10.